### PR TITLE
Setting to control showing window name in window title, fixes #31

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -156,12 +156,12 @@ async function onRequest(request) {
         case 'help':
             return Action.openHelp();
         case 'update': {
-            const { windowId, name } = request;
+            const { windowId, name, clearTitlePreface } = request;
             if (windowId && name)
-                return Chrome.update([[windowId, name]]);
+                return Chrome.update([[windowId, name]], clearTitlePreface);
             const winfos = await Winfo.getAll(['givenName']);
             const nameMap = (new Name.NameMap()).populate(winfos);
-            return Chrome.update(nameMap);
+            return Chrome.update(nameMap, clearTitlePreface);
         }
         case 'warn':
             return Chrome.showWarningBadge();

--- a/background/chrome.js
+++ b/background/chrome.js
@@ -10,13 +10,16 @@ export function showWarningBadge() {
 }
 
 //@ (Map(Number:String)|[[Number, String]]), state -> state
-export async function update(nameMap) {
-    const [prefix, postfix, show_badge] =
-        await Settings.getValue(['title_preface_prefix', 'title_preface_postfix', 'show_badge']);
+export async function update(nameMap, clearTitlePreface = false) {
+    const [prefix, postfix, show_badge, show_title] =
+        await Settings.getValue(['title_preface_prefix', 'title_preface_postfix', 'show_badge', 'show_title']);
     for (const [windowId, name] of nameMap) {
         const titlePreface = name ?
             (prefix + name + postfix) : '';
-        updateTitlebar(windowId, titlePreface);
+
+        if (show_title || clearTitlePreface)
+            updateTitlebar(windowId, show_title ? titlePreface : '');
+
         updateButtonTitle(windowId, titlePreface);
         updateBadge(windowId, show_badge ? name : '');
     }

--- a/options/options.html
+++ b/options/options.html
@@ -27,6 +27,7 @@
           <label><span>Postfix</span> <input class="setting affixField" type="text" name="title_preface_postfix"></label>
         </div>
         <hr>
+        <label><input class="setting" type="checkbox" name="show_title"> <span>Show window name in window title</span></label>
         <label><input class="setting" type="checkbox" name="show_badge"> <span>Show window name on the Winger button
           <br><small>(Limited to the first few characters)</small>
         </span></label>

--- a/options/options.js
+++ b/options/options.js
@@ -153,6 +153,9 @@ $form.addEventListener('change', async ({ target: $field }) => {
         case 'show_badge':
             browser.runtime.sendMessage({ type: 'update' });
             return;
+        case 'show_title':
+            browser.runtime.sendMessage({ type: 'update', clearTitlePreface: true });
+            return;
 
         case 'theme':
             document.body.classList.toggle('dark', isDark($form.theme.value));

--- a/settings.js
+++ b/settings.js
@@ -10,6 +10,7 @@ const ALL_DEFAULTS = {
     title_preface_prefix: '',
     title_preface_postfix: ' - ',
     show_badge: false,
+    show_title: true,
 
     enable_stash: false,
     stash_home_root: 'toolbar_____',


### PR DESCRIPTION
I added a new option that controls if the window `titlePreface` is set to a window's name. I also made sure that disabling this new option would clear any existing names. This should fix #31.