### PR TITLE
Setting to allow searching based on window title

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -140,7 +140,7 @@ async function onRequest(request) {
         case 'popup': {
             const [winfos, settings, allowedPrivate] = await Promise.all([
                 Winfo.getAll(['focused', 'givenName', 'incognito', 'lastFocused', 'minimized', 'tabCount', 'titleSansName', 'type']),
-                Settings.getDict(['show_popup_bring', 'show_popup_send', 'enable_stash']),
+                Settings.getDict(['show_popup_bring', 'show_popup_send', 'enable_stash', 'filter_window_titles']),
                 browser.extension.isAllowedIncognitoAccess(),
             ]);
             return { ...Winfo.arrange(winfos), settings, allowedPrivate };

--- a/options/options.html
+++ b/options/options.html
@@ -58,6 +58,11 @@
       </fieldset>
 
       <fieldset>
+        <legend>Filtering / Searching</legend>
+        <label><input class="setting" type="checkbox" name="filter_window_titles"> <span>Filter based on window title if the window is unnamed</span></label>
+      </fieldset>
+
+      <fieldset>
         <legend>Theme</legend>
         <div class="inline-fields gap">
           <label><input class="setting" type="radio" name="theme" value=""> <span>Auto</span></label>

--- a/popup/common.js
+++ b/popup/common.js
@@ -20,9 +20,11 @@ export const isInToolbar = $el => $el?.parentElement === $toolbar;
 
 // Given a $row or any of its child elements, get the givenName.
 //@ (Object) -> (String)
-export function getName($el) {
+export function getName($el, fallbackToPlaceholder = false) {
     const $name = isNameField($el) && $el || $el.$name || $el.$row.$name;
-    return $name.value;
+    const value = $name.value;
+    if (!value && fallbackToPlaceholder) return $name.placeholder;
+    else return value;
 }
 
 export const nameMap = new NameMap();

--- a/popup/filter.js
+++ b/popup/filter.js
@@ -5,10 +5,12 @@ import {
 } from './common.js';
 
 export let $shownRows; // Visible other window rows
+let filterByWindowTitles;
 
 //@ state -> state
-export function init() {
+export function init({ filter_window_titles }) {
     $shownRows = [...$otherWindowRows];
+    filterByWindowTitles = filter_window_titles
 }
 
 // Show only rows whose names contain str, and sort them by name length, shortest first.
@@ -39,7 +41,7 @@ function filter(str) {
     $otherWindowRows.$minHeading.hidden = true;
     const $filteredRows = [];
     for (const $row of $otherWindowRows) {
-        const name = getName($row).toUpperCase();
+        const name = getName($row, filterByWindowTitles).toUpperCase();
         const isMatch = name.includes(str);
         $row.hidden = !isMatch;
         if (isMatch) {

--- a/popup/init.js
+++ b/popup/init.js
@@ -23,7 +23,7 @@ function onSuccess({ currentWinfo, otherWinfos, settings, allowedPrivate }) {
 
     Omnibox.init(settings, allowedPrivate);
     Status.init(currentWinfo, otherWinfos, settings);
-    Filter.init();
+    Filter.init(settings);
     indicateReopenTabs();
     lockHeight($otherWindowsList);
 }

--- a/settings.js
+++ b/settings.js
@@ -14,6 +14,7 @@ const ALL_DEFAULTS = {
     enable_stash: false,
     stash_home_root: 'toolbar_____',
     stash_home_folder: 'Stashed Windows',
+    filter_window_titles: false,
 
     theme: '',
 


### PR DESCRIPTION
Currently Winger only filters the popup based on window names, so if you haven't named any window the filter feature can't be used. This PR adds a setting to allow searching window titles for unnamed windows. This is especially useful when combined with other addons that set window names in the window title, such as [Other Window](https://addons.mozilla.org/firefox/addon/otherwindow/) or [Tab Count in Window Title](https://addons.mozilla.org/firefox/addon/tab-count-in-window-title/), which should be possible after #31 is fixed.
