### PR TITLE
Fix Shift modifier not detected on keyboard Enter for action buttons

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -6,6 +6,7 @@ import {
     $otherWindowsList,
     $toolbar,
     $status,
+    isButton,
     isRow,
 } from './common.js';
 import * as EditMode from './editmode.js';
@@ -118,6 +119,15 @@ function onContextMenu(event) {
 function onKeyDown(event) {
     if (Omnibox.handleKeyDown(event))
         return;
+    if (event.key === 'Enter') {
+        const { target } = event;
+        const $action = isButton(target) ? target.closest('[data-action]') : null;
+        if ($action && $action.tabIndex !== -1 && $action.dataset.action !== 'togglePrivate') {
+            event.preventDefault();
+            Request.action({ event, $action });
+            return;
+        }
+    }
     Navigation.handleKeyDown(event);
     Status.update(event);
 }


### PR DESCRIPTION
On macOS Firefox, pressing Enter on a focused button synthesizes a click event that doesn't reliably preserve modifier key state. Handle Enter on action buttons in `onKeyDown` instead, using the keyboard event which correctly reports `shiftKey`.

Fixes #78

Note: This fix was written by Claude Code. I'm not a front-end engineer and I'm not a good judge of whether this is a reasonable fix. But I've been testing it for about a week and it works fine with no unwanted side effects as far as I can see.