### PR TITLE
Send tabs to top

### DIFF
--- a/background/action.js
+++ b/background/action.js
@@ -105,12 +105,13 @@ async function bringTabs(request) {
  * @returns {Promise<Tab[]>}
  */
 async function sendTabs(request) {
-    const [tabs, { keep_moved_tabs_selected, discard_minimized_window }] = await Promise.all([
+    const [tabs, { keep_moved_tabs_selected, discard_minimized_window, send_tab_to_top }] = await Promise.all([
         request.tabs ?? getSelectedTabs(), // If tabs not given in request, get selected tabs
-        Storage.getDict(['keep_moved_tabs_selected', 'discard_minimized_window']),
+        Storage.getDict(['keep_moved_tabs_selected', 'discard_minimized_window', 'send_tab_to_top']),
     ]);
     request.tabs ??= tabs;
     request.keep_moved_tabs_selected = keep_moved_tabs_selected;
+    request.send_tab_to_top = send_tab_to_top;
 
     const movedTabs = await moveTabs(request);
     if (movedTabs.length) {
@@ -130,7 +131,7 @@ async function sendTabs(request) {
  * @param {ActionRequest} request
  * @returns {Promise<Tab[]>}
  */
-async function moveTabs({ tabs, windowId, keep_moved_tabs_selected }) {
+async function moveTabs({ tabs, windowId, keep_moved_tabs_selected, send_tab_to_top }) {
     const [pinnedTabs, unpinnedTabs] = splitTabsByPinnedState(tabs);
 
     // Get destination index for pinned tabs, since they cannot be moved to index -1 if unpinned tabs exist at destination
@@ -145,7 +146,7 @@ async function moveTabs({ tabs, windowId, keep_moved_tabs_selected }) {
 
     /** @type {Tab[]} */ const movedTabs = (await Promise.all([
         browser.tabs.move(pinnedTabs.map(tab => tab.id), { windowId, index }),
-        browser.tabs.move(unpinnedTabs.map(tab => tab.id), { windowId, index: -1 }),
+        browser.tabs.move(unpinnedTabs.map(tab => tab.id), { windowId, index: send_tab_to_top ? 0 : -1 }),
     ])).flat();
 
     if (!movedTabs.length)

--- a/page/options.html
+++ b/page/options.html
@@ -14,6 +14,7 @@
         <div class="group">
           <label><input class="setting" type="checkbox" name="show_popup_send_btn"> <span>Show send buttons in pop-up panel</span></label>
           <label><input class="setting" type="checkbox" name="show_popup_bring_btn"> <span>Show bring buttons in pop-up panel</span></label>
+          <label><input class="setting" type="checkbox" name="send_tab_to_top"> <span>Send tab to the top of tabs (vertical tabs) or send the tab to the first position (horizontal tabs)</span></label>
         </div>
         <p>When sending or bringing tabs...</p>
         <div class="group">

--- a/storage.js
+++ b/storage.js
@@ -11,6 +11,7 @@ export const STORED_PROPS = {
     show_popup_bring_btn: true,
     show_popup_send_btn: true,
     keep_moved_tabs_selected: true,
+    send_tab_to_top: false,
 
     discard_minimized_window: false,
     discard_minimized_window_delay_mins: 0,


### PR DESCRIPTION
This adds an option that when enabled sends tabs to the top (when using vertical tabs) or index 0 when using horizontal tabs.

I personally use Zen with vertical tabs, and having Winger send tabs to the bottom is annoying to work with.
I'm not exactly sure what to put for the option description in regards to horizontal tabs, so if you have a better description in mind that would be great.