### PR TITLE
Fix confusing keyboard navigation in popup rows

### DIFF
--- a/popup/navigation.js
+++ b/popup/navigation.js
@@ -127,8 +127,7 @@ const Navigator = {
             return $el;
         if (isInToolbar($el))
             return $el.nextElementSibling || $toolbar.querySelector('button');
-        return isRow($el) ? $el.firstElementChild :
-            ($el.nextElementSibling || $el.$row);
+        return horizontalStep(row($el), $el, +1);
     },
 
     /** @type {KeyProcessor} */
@@ -139,8 +138,7 @@ const Navigator = {
             return $el;
         if (isInToolbar($el))
             return $el.previousElementSibling || $toolbar.querySelector('button:last-child');
-        return isRow($el) ? $el.lastElementChild :
-            ($el.previousElementSibling || $el.$row);
+        return horizontalStep(row($el), $el, -1);
     },
 
     /** @type {KeyProcessor} */
@@ -232,6 +230,50 @@ const rowOrCell = $row => isEditMode && $row?.$name || Column.getCell($row) || $
  * @returns {WindowRow$}
  */
 const row = $el => $el.$row || $el;
+
+/**
+ * Ordered horizontal focus stops for a row: left buttons, a single central stop, then right buttons.
+ * The central stop is the name field where it is focusable (current-window row), else the row itself,
+ * so that moving inward re-selects the whole row.
+ * @param {WindowRow$} $row
+ * @returns {HTMLElement[]}
+ */
+function horizontalStops($row) {
+    const $centre = $row.$name?.tabIndex === -1 ? $row : $row.$name;
+    const $stops = [];
+    let centreAdded = false;
+    for (const $child of $row.children) {
+        if (isButton($child)) {
+            $stops.push($child);
+        } else if (!centreAdded) {
+            // First non-button (the icon) marks the central region; add the central stop once
+            $stops.push($centre);
+            centreAdded = true;
+        }
+    }
+    if (!centreAdded)
+        $stops.push($centre);
+    return $stops;
+}
+
+/**
+ * Move from `$el` to the nearest focusable horizontal stop in `dir`, or stay put at a row's edge.
+ * @param {WindowRow$} $row
+ * @param {HTMLElement} $el
+ * @param {1 | -1} dir
+ * @returns {HTMLElement}
+ */
+function horizontalStep($row, $el, dir) {
+    const $stops = horizontalStops($row);
+    const index = $stops.indexOf($el);
+    if (index === -1)
+        return $el;
+    for (let i = index + dir; i >= 0 && i < $stops.length; i += dir) {
+        if (!isUnfocusable($stops[i]))
+            return $stops[i];
+    }
+    return $el;
+}
 
 /** @returns {HTMLElement} */ const currentWindow = () => Column.getCell($currentWindowRow) || $currentWindowRow.$name || $currentWindowRow;
 /** @returns {HTMLElement} */ const toolbar = () => $toolbar.querySelector('button') || $toolbar;


### PR DESCRIPTION
Fixes #85

## Problem

When navigating the popup drop-down by keyboard, the current-window row and the other rows behaved inconsistently. On the current-window row focus starts on the centre (the window name) and arrow keys move left/right intuitively. But on other rows, where the whole row is selected, the first arrow press was asymmetric: Right jumped to the leftmost button (Send) and Left jumped to the rightmost button (Stash). This made the mental model hard — focus appeared to start off either the left *or* the right of the row depending on which key was pressed first.

A related awkwardness: once focus moved off the row onto a button, there was no natural way to re-select the whole row — you had to wrap all the way around off the far edge.

## Fix

Each row now has an explicit, ordered set of horizontal focus stops with the **row itself as a genuine central stop**:

```
Send · Bring · [ ROW ] · Stash
```

- Row selected → **Right** moves to Stash, **Left** moves to Bring/Send.
- **Stash → Left** and **Bring → Right** re-select the whole row, so you can get back to the row selection naturally.
- At a row's edges (Send + Left, Stash + Right) focus stays put — no more wrap-around to the far side.

The central stop is the name field where it is focusable (current-window row / edit mode) and the row element otherwise, so all rows now share the same intuitive left-is-left / right-is-right model.

Implemented in `popup/navigation.js` via two helpers (`horizontalStops`, `horizontalStep`) that the `ArrowRight`/`ArrowLeft` handlers delegate to; disabled buttons are skipped.